### PR TITLE
Remove classifier from jcardsim dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,6 @@
             <groupId>com.licel</groupId>
             <artifactId>jcardsim</artifactId>
             <version>2.2.1</version>
-            <classifier>2013-12-12-all</classifier>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The classifier in the pom.xml for jcardsim dependency broke the build.
